### PR TITLE
Added additional content check to query file validation

### DIFF
--- a/lib/censuscope.py
+++ b/lib/censuscope.py
@@ -187,6 +187,7 @@ def validate_query_file(query_path: str):
         with open(query_path, "r") as f:
             expecting_sequence = False
             record_count = 0
+			current_header = None
 
             for line_num, line in enumerate(f, start=1):
                 stripped = line.strip()
@@ -198,7 +199,7 @@ def validate_query_file(query_path: str):
                     if expecting_sequence:
                         raise ValueError(
                             f"Invalid FASTA file '{query_path}': "
-                            f"previous header has no sequence before line {line_num}. "
+                            f"header '{current_header}' has no sequence. "
                             f"Please check your input file and make sure every '>' header "
                             f"is followed by a valid nucleotide sequence."
                         )

--- a/lib/censuscope.py
+++ b/lib/censuscope.py
@@ -187,7 +187,7 @@ def validate_query_file(query_path: str):
         with open(query_path, "r") as f:
             expecting_sequence = False
             record_count = 0
-			current_header = None
+            current_header = None
 
             for line_num, line in enumerate(f, start=1):
                 stripped = line.strip()

--- a/lib/censuscope.py
+++ b/lib/censuscope.py
@@ -203,17 +203,12 @@ def validate_query_file(query_path: str):
                             f"Please check your input file and make sure every '>' header "
                             f"is followed by a valid nucleotide sequence."
                         )
-
+                
                     record_count += 1
                     expecting_sequence = True
-
+                    current_header = stripped
+					
                 else:
-                    if record_count == 0:
-                        raise ValueError(
-                            f"Invalid FASTA file '{query_path}': "
-                            f"sequence found before any '>' header at line {line_num}."
-                        )
-
                     if not valid_nucleotide_regex.fullmatch(stripped):
                         raise ValueError(
                             f"Invalid FASTA file '{query_path}': "
@@ -298,11 +293,11 @@ def validate_query_file(query_path: str):
                 raise ValueError(f"Invalid FASTQ file '{query_path}': no records found.")
 
     else:
-        head_char = first_line[:1]
         raise ValueError(
-            f"Input file '{query_path}' does not appear to be a valid FASTA or FASTQ file. "
-            f"Expected first character '>' (FASTA) or '@' (FASTQ), got '{head_char}'. "
-            f"Please check the file contents."
+            f"Invalid input file '{query_path}': "
+            f"the first non-empty line does not start with '>' (FASTA) or '@' (FASTQ). "
+            f"Please check your input file. Remove any unnecessary text before the first sequence, "
+            f"or ensure each sequence has a proper header ('>' for FASTA or '@' for FASTQ)."
         )
 
     logger.info(

--- a/lib/censuscope.py
+++ b/lib/censuscope.py
@@ -203,11 +203,11 @@ def validate_query_file(query_path: str):
                             f"Please check your input file and make sure every '>' header "
                             f"is followed by a valid nucleotide sequence."
                         )
-                
+
                     record_count += 1
                     expecting_sequence = True
                     current_header = stripped
-					
+
                 else:
                     if not valid_nucleotide_regex.fullmatch(stripped):
                         raise ValueError(

--- a/lib/censuscope.py
+++ b/lib/censuscope.py
@@ -15,6 +15,7 @@ import time
 from collections import defaultdict
 from datetime import datetime
 from threading import Thread, Lock
+import re
 
 write_lock = Lock()
 
@@ -147,46 +148,166 @@ def usr_args():
 
 def validate_query_file(query_path: str):
     """
-	Check the input file existence, file extension, and content format(">". "@")
+    Check input file existence, file extension, format, and content(header, sequence).
     """
+
+    valid_nucleotide_regex = re.compile(r'^[ACGTUNRYKMSWBDHVacgtunrykmswbdhv]+$') #Including IUPAC ambiguity codes
+
     # File existence
     if not os.path.isfile(query_path):
         raise FileNotFoundError(f"Input file not found: {query_path}")
 
-    # Extension check
+    # File extension
     valid_extensions = {".fastq", ".fq", ".fasta", ".fa"}
     _, ext = os.path.splitext(query_path)
     if ext.lower() not in valid_extensions:
         raise ValueError(
             f"Unsupported input file format '{ext}'. "
-            f"CensusScope only accepts FASTA or FASTQ files "
+            f"CensusScope only accepts FASTA or FASTQ files. "
             f"({', '.join(sorted(valid_extensions))})."
         )
 
-    # Content check
+    # Read first non-empty line to detect format
     try:
-        head_char = subprocess.run(
-            f"head -n 1 {query_path} | cut -c1",
-            shell=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True
-        ).stdout.strip()
-    except subprocess.CalledProcessError as e:
+        with open(query_path, "r") as f:
+            first_line = ""
+            for line in f:
+                first_line = line.strip()
+                if first_line:
+                    break
+    except OSError as e:
         raise ValueError(f"Could not read input file '{query_path}': {e}")
 
-    if head_char == ">":
+    if not first_line:
+        raise ValueError(f"Input file '{query_path}' is empty.")
+
+    if first_line.startswith(">"):
         detected_format = "FASTA"
-    elif head_char == "@":
+
+        with open(query_path, "r") as f:
+            expecting_sequence = False
+            record_count = 0
+
+            for line_num, line in enumerate(f, start=1):
+                stripped = line.strip()
+
+                if not stripped:
+                    continue
+
+                if stripped.startswith(">"):
+                    if expecting_sequence:
+                        raise ValueError(
+                            f"Invalid FASTA file '{query_path}': "
+                            f"previous header has no sequence before line {line_num}. "
+                            f"Please check your input file and make sure every '>' header "
+                            f"is followed by a valid nucleotide sequence."
+                        )
+
+                    record_count += 1
+                    expecting_sequence = True
+
+                else:
+                    if record_count == 0:
+                        raise ValueError(
+                            f"Invalid FASTA file '{query_path}': "
+                            f"sequence found before any '>' header at line {line_num}."
+                        )
+
+                    if not valid_nucleotide_regex.fullmatch(stripped):
+                        raise ValueError(
+                            f"Invalid FASTA file '{query_path}': "
+                            f"invalid sequence at line {line_num}. "
+                            f"Only valid nucleotide characters are allowed."
+                        )
+
+                    expecting_sequence = False
+
+            if record_count == 0:
+                raise ValueError(f"Invalid FASTA file '{query_path}': no FASTA records found.")
+
+            if expecting_sequence:
+                raise ValueError(
+                    f"Invalid FASTA file '{query_path}': "
+                    f"last header has no sequence. "
+                    f"Please check your input file."
+                )
+
+    elif first_line.startswith("@"):
         detected_format = "FASTQ"
+
+        with open(query_path, "r") as f:
+            record_num = 0
+
+            while True:
+                header = f.readline()
+                if not header:
+                    break
+
+                if not header.strip():
+                    continue
+
+                seq = f.readline()
+                plus = f.readline()
+                qual = f.readline()
+
+                record_num += 1
+
+                if not seq or not plus or not qual:
+                    raise ValueError(
+                        f"Invalid FASTQ file '{query_path}': incomplete record at record {record_num}."
+                    )
+
+                header = header.rstrip("\n\r")
+                seq = seq.rstrip("\n\r")
+                plus = plus.rstrip("\n\r")
+                qual = qual.rstrip("\n\r")
+
+                if not header.startswith("@"):
+                    raise ValueError(
+                        f"Invalid FASTQ file '{query_path}': "
+                        f"record {record_num} header does not start with '@'."
+                    )
+
+                if not seq:
+                    raise ValueError(
+                        f"Invalid FASTQ file '{query_path}': "
+                        f"record {record_num} has empty sequence."
+                    )
+
+                if not valid_nucleotide_regex.fullmatch(seq):
+                    raise ValueError(
+                        f"Invalid FASTQ file '{query_path}': "
+                        f"record {record_num} contains invalid nucleotide characters."
+                    )
+
+                if not plus.startswith("+"):
+                    raise ValueError(
+                        f"Invalid FASTQ file '{query_path}': "
+                        f"record {record_num} third line does not start with '+'."
+                    )
+
+                if len(seq) != len(qual):
+                    raise ValueError(
+                        f"Invalid FASTQ file '{query_path}': "
+                        f"record {record_num} sequence length ({len(seq)}) does not match "
+                        f"quality length ({len(qual)})."
+                    )
+
+            if record_num == 0:
+                raise ValueError(f"Invalid FASTQ file '{query_path}': no records found.")
+
     else:
+        head_char = first_line[:1]
         raise ValueError(
             f"Input file '{query_path}' does not appear to be a valid FASTA or FASTQ file. "
             f"Expected first character '>' (FASTA) or '@' (FASTQ), got '{head_char}'. "
             f"Please check the file contents."
         )
 
-    logger.info(f"Input file validated: {query_path} (extension: {ext}, detected format: {detected_format})")
+    logger.info(
+        f"Input file validated: {query_path} "
+        f"(extension: {ext}, detected format: {detected_format})"
+    )
 
 def validate_database(database: str):
     """


### PR DESCRIPTION
Added content validation for FASTA and FASTQ inputs.
For FASTA, checks ensure each header (>) is followed by a valid nucleotide sequence and that sequences contain only allowed IUPAC characters. For FASTQ, validation enforces correct 4-line record structure, verifies headers start with @, ensures sequences contain valid nucleotide characters, checks the + line format, and confirms sequence and quality lengths match. Invalid or incomplete records raise clear error messages.